### PR TITLE
update:送出觀看者訂閱層級到mux data作識別

### DIFF
--- a/src/components/HlsPlayer.vue
+++ b/src/components/HlsPlayer.vue
@@ -152,7 +152,9 @@ function setupPlayer(src, mode = 'member') {
         env_key: MUX_ENV_KEY,
         video_id: props.src, // 之後可換課程 ID
         video_title: props.poster ?? '',
-        viewer_user_id: localStorage.getItem('uid') || '',
+        viewer_user_id:
+          JSON.parse(localStorage.getItem('user') || '{}').id || '',
+        viewer_plan: props.mode || 'preivew',
         player_name: 'Sportify Plus HLS Player',
         player_init_time: Date.now()
       }


### PR DESCRIPTION
1. 修改mux data未正確取得 viewer_user_id問題
2. 為區分試看與會員上課的觀看紀錄，將props.mode (值會是member或preview)傳給mux